### PR TITLE
Make canvas resizable

### DIFF
--- a/src/projectile_motion/animation.py
+++ b/src/projectile_motion/animation.py
@@ -10,11 +10,16 @@ class ProjectileMotionAnimation(Canvas):
             width=1, height=1, highlightthickness=0, bg='skyblue')
         self.bind("<Configure>", self.on_resize)
 
-        self.floor_height = None
+        # Ball attributes
         self.ball = None
+        self.offset = 10
+        self.diameter = 50
+        # Floor attributes
         self.floor = None
+        self.floor_height = None
 
         # Variables during animation
+        self.animation_running = False
         self.h_vel = None
         self.v_vel = None
         self.time = None
@@ -45,8 +50,6 @@ class ProjectileMotionAnimation(Canvas):
 
     def draw_ball(self, resize = False):
         """Draw ball on top of the floor"""
-        diameter = 50
-        offset = 10
         # The -1 is added to raise it one pixel up from the floor so
         # that it lies flat on top of the floor, or else it would
         # dig into the floor one pixel
@@ -56,12 +59,19 @@ class ProjectileMotionAnimation(Canvas):
             tl_x, br_x = cur_ball_coords[0], cur_ball_coords[2]
             self.coords(
                 self.ball,
-                tl_x, self.floor_height-diameter-1,
+                tl_x, self.floor_height-self.diameter-1,
                 br_x, self.floor_height-1)
         else:
             self.ball = self.create_oval(
-                offset, self.floor_height-diameter-1,
-                offset+diameter, self.floor_height-1, fill='red')
+                self.offset, self.floor_height-self.diameter-1,
+                self.offset+self.diameter, self.floor_height-1, fill='red')
+
+    def reset_ball_position(self):
+        """Brings ball back to its default position"""
+        self.coords(
+                self.ball,
+                self.offset, self.floor_height-self.diameter-1,
+                self.offset+self.diameter, self.floor_height-1)
 
     def start_animation(self, init_vel, angle):
         """Starts the animation"""
@@ -78,6 +88,7 @@ class ProjectileMotionAnimation(Canvas):
 
         self.starting_ball_coords = self.coords(self.ball)
 
+        self.animation_running = True
         self.do_animation()
 
     def do_animation(self):
@@ -117,6 +128,19 @@ class ProjectileMotionAnimation(Canvas):
         self.no_of_frames = None
         self.total_no_of_frames = None
 
+    def abort_animation(self, msg = ""):
+        """Aborts the animation by bringing the ball back down to the
+        floor. Happens when the window is resized."""
+        self.reset_animation_vars()
+        self.reset_ball_position()
+
+        self.show_message(msg)
+
+    def show_message(self, msg):
+        """Adds some temporary text to the top left corner of the canvas"""
+        text = self.create_text(10, 10, text=msg, anchor=NW)
+        self.after(2000, lambda: self.delete(text))
+
     def on_resize(self, event):
         """Makes sure that the ball and floor are brought up to the
         bottom of the canvas upon resizing."""
@@ -124,3 +148,5 @@ class ProjectileMotionAnimation(Canvas):
             self.draw_floor(resize=True)
         if (self.ball is not None):
             self.draw_ball(resize=True)
+            if self.animation_running:
+                self.abort_animation("Animation aborted due to resize")

--- a/src/projectile_motion/animation.py
+++ b/src/projectile_motion/animation.py
@@ -21,6 +21,9 @@ class ProjectileMotionAnimation(Canvas):
         self.no_of_frames = None
         self.total_no_of_frames = None
 
+        self.time_to_total_frames_multiplier = 20
+        self.upc = 5  # unit to pixel conversion
+
     def setup_canvas(self):
         """Draw all needed components for the projectile motion 
         animation"""
@@ -32,7 +35,8 @@ class ProjectileMotionAnimation(Canvas):
         w, h = self.winfo_width(), self.winfo_height()
         # Set floor height
         self.floor_height = h - 10
-        self.create_rectangle(0, self.floor_height, w, h, fill='sienna3', outline='sienna3')
+        self.create_rectangle(
+            0, self.floor_height, w, h, fill='sienna3', outline='sienna3')
 
     def draw_ball(self):
         """Draw ball on top of the floor"""
@@ -53,7 +57,8 @@ class ProjectileMotionAnimation(Canvas):
         self.total_time = self.v_vel / ((1/2)*self.g)
 
         self.no_of_frames = 0
-        self.total_no_of_frames = round(self.total_time * 20)
+        self.total_no_of_frames = \
+            round(self.total_time * self.time_to_total_frames_multiplier)
         self.time_step = self.total_time / self.total_no_of_frames
         self.time = self.time_step
 
@@ -67,8 +72,9 @@ class ProjectileMotionAnimation(Canvas):
             return  
 
         # x and y displacement
-        x_disp = (self.h_vel * self.time) * 5
-        y_disp = ((self.v_vel*self.time) + ((1/2)*-self.g*(self.time**2))) * 5
+        x_disp = (self.h_vel * self.time) * self.upc
+        y_disp = ((self.v_vel*self.time)
+                 + ((1/2)*-self.g*(self.time**2))) * self.upc
 
         # Get the starting coordinates of the ball
         # tl = top left    # br = bottom right

--- a/src/projectile_motion/animation.py
+++ b/src/projectile_motion/animation.py
@@ -8,9 +8,11 @@ class ProjectileMotionAnimation(Canvas):
     def __init__(self):
         super().__init__(
             width=1, height=1, highlightthickness=0, bg='skyblue')
+        self.bind("<Configure>", self.on_resize)
 
         self.floor_height = None
         self.ball = None
+        self.floor = None
 
         # Variables during animation
         self.h_vel = None
@@ -30,24 +32,36 @@ class ProjectileMotionAnimation(Canvas):
         self.draw_floor()
         self.draw_ball()
     
-    def draw_floor(self):
+    def draw_floor(self, resize = False):
         """Draw floor of the projectile motion animation"""
         w, h = self.winfo_width(), self.winfo_height()
         # Set floor height
         self.floor_height = h - 10
-        self.create_rectangle(
-            0, self.floor_height, w, h, fill='sienna3', outline='sienna3')
+        if resize:
+            self.coords(self.floor, 0, self.floor_height, w, h)
+        else:
+            self.floor = self.create_rectangle(
+                0, self.floor_height, w, h, fill='sienna3', outline='sienna3')
 
-    def draw_ball(self):
+    def draw_ball(self, resize = False):
         """Draw ball on top of the floor"""
         diameter = 50
         offset = 10
         # The -1 is added to raise it one pixel up from the floor so
         # that it lies flat on top of the floor, or else it would
         # dig into the floor one pixel
-        self.ball = self.create_oval(
-            offset, self.floor_height-diameter-1,
-            offset+diameter, self.floor_height-1, fill='red')
+        if resize:
+            cur_ball_coords = self.coords(self.ball)
+            # Retain x coordinates. We only change y coordinates upon resize.
+            tl_x, br_x = cur_ball_coords[0], cur_ball_coords[2]
+            self.coords(
+                self.ball,
+                tl_x, self.floor_height-diameter-1,
+                br_x, self.floor_height-1)
+        else:
+            self.ball = self.create_oval(
+                offset, self.floor_height-diameter-1,
+                offset+diameter, self.floor_height-1, fill='red')
 
     def start_animation(self, init_vel, angle):
         """Starts the animation"""
@@ -63,6 +77,7 @@ class ProjectileMotionAnimation(Canvas):
         self.time = self.time_step
 
         self.starting_ball_coords = self.coords(self.ball)
+
         self.do_animation()
 
     def do_animation(self):
@@ -93,6 +108,7 @@ class ProjectileMotionAnimation(Canvas):
         self.after(1000//30, self.do_animation)
 
     def reset_animation_vars(self):
+        self.animation_running = False
         self.h_vel = None
         self.v_vel = None
         self.time = None
@@ -100,3 +116,11 @@ class ProjectileMotionAnimation(Canvas):
         self.time_step = None
         self.no_of_frames = None
         self.total_no_of_frames = None
+
+    def on_resize(self, event):
+        """Makes sure that the ball and floor are brought up to the
+        bottom of the canvas upon resizing."""
+        if self.floor is not None:
+            self.draw_floor(resize=True)
+        if (self.ball is not None):
+            self.draw_ball(resize=True)

--- a/src/projectile_motion/window.py
+++ b/src/projectile_motion/window.py
@@ -20,6 +20,7 @@ class MainWindow:
         sc_width, sc_height = self.root.winfo_screenwidth(), self.root.winfo_screenheight()
         # self.root.geometry(f"{sc_width}x{sc_height}")
         self.root.state('zoomed')
+        self.root.minsize(512, 288)
 
         # Set grid weight
         self.root.rowconfigure(0, weight=4)


### PR DESCRIPTION
The canvas and its items no longer break after being resized. The ball and floor are not resized, but simply brought up to make sure that their base remains the bottom of the canvas.

An `abort_animation()` function was also created to allow an animation to be promptly stopped if a user resized the window while an animation was going on. A `show_message()` function was created so that the user would know why the animation was stopped,  though it could be useful for other things in the future as well.